### PR TITLE
bugfix: invalidate current watchers if connections is being reset

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -374,12 +374,14 @@ func (c *Conn) connect() error {
 
 		if retryStart {
 			c.flushUnsentRequests(ErrNoServer)
+			c.invalidateWatches(ErrNoServer)
 			select {
 			case <-time.After(time.Second):
 				// pass
 			case <-c.shouldQuit:
 				c.setState(StateDisconnected)
 				c.flushUnsentRequests(ErrClosing)
+				c.invalidateWatches(ErrClosing)
 				return ErrClosing
 			}
 		}


### PR DESCRIPTION
This PR pulls in go-zookeeper/zk#84